### PR TITLE
Fix mkdir issue in create_placeholder()

### DIFF
--- a/lib/App/Kains/Core.pm6
+++ b/lib/App/Kains/Core.pm6
@@ -83,7 +83,7 @@ multi sub create-placeholder(IO::Path $source, IO::Path $destination)
 	multi sub paths(IO() $path where * cmp '/' === Same) { $path }
 	multi sub paths(IO() $path) { paths($path.parent), $path }
 
-	.mkdir.e if ! .e for paths $destination.parent;
+	.mkdir if ! .e for paths $destination.parent;
 
 	given $source {
 		when .f { close open ~$destination, :a }


### PR DESCRIPTION
Replace mkdir.e typo with .mkdir when creating parent directories
in create_placeholder() method.

Observed when binding directories when the guest parent dir does
not exist, error was reported as:
Error ...: No such method 'e' for invocant of type 'Bool'
