### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/App/Kains.pm6
+++ b/lib/App/Kains.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains;
+unit module App::Kains;
 
 use App::Kains::Parameters;
 use App::Kains::Core;

--- a/lib/App/Kains/Commandline.pm6
+++ b/lib/App/Kains/Commandline.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains::Command-line;
+unit module App::Kains::Command-line;
 
 class Param is export {
 	has Str  @.switches;

--- a/lib/App/Kains/Config.pm6
+++ b/lib/App/Kains/Config.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains::Config;
+unit module App::Kains::Config;
 
 class Config is export {
 	has Str $.rootfs	 = '/';

--- a/lib/App/Kains/Core.pm6
+++ b/lib/App/Kains/Core.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains::Core;
+unit module App::Kains::Core;
 
 use App::Kains::Core::Chrooted;
 use App::Kains::Native;

--- a/lib/App/Kains/Core/Chrooted.pm6
+++ b/lib/App/Kains/Core/Chrooted.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains::Core::Chrooted;
+unit module App::Kains::Core::Chrooted;
 
 use App::Kains::Config;
 use App::Kains::Native;

--- a/lib/App/Kains/Native.pm6
+++ b/lib/App/Kains/Native.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains::Native;
+unit module App::Kains::Native;
 
 use NativeCall;
 

--- a/lib/App/Kains/Parameters.pm6
+++ b/lib/App/Kains/Parameters.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains::Parameters;
+unit module App::Kains::Parameters;
 
 use App::Kains::Config;
 use App::Kains::Commandline;

--- a/lib/App/Kains/X.pm6
+++ b/lib/App/Kains/X.pm6
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-module App::Kains::X;
+unit module App::Kains::X;
 
 class X::Kains is Exception is export {
 	has Str $.message;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
