### PR TITLE
Fix travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: perl6
 perl6:
   - latest


### PR DESCRIPTION
For testing kains, the full VM travis CI infrastructure must be
used as the container base infrastructure is not able to run
Linux containers itself.

Force allocation of a full VM node with "sudo: required" in
.travis.yml.
